### PR TITLE
feat: arrays delimiter

### DIFF
--- a/bin/algolia-upload.js
+++ b/bin/algolia-upload.js
@@ -12,19 +12,19 @@ function readConfig(argv) {
   var urlStartPattern = /http(?:s)*:\/\//;
 
   if( args._.length !== 4) {
-    console.error( "Usage : algolia-upload APP_ID API_KEY indexName file|url [-d ','] [-b 10000] [--clear-index] [--parse-arrays=column] [--geo-columns=lat_col,long_col] [--arrays-delimiter=',']" );
+    console.error( "Usage : algolia-upload APP_ID API_KEY indexName file|url [-d ','] [-b 10000] [--clear-index] [--parse-arrays=column] [--arrays-delimiter=','] [--geo-columns=lat_col,long_col]" );
     return undefined;
   }
 
   var parseArrays;
-  if(Array.isArray(args['parse-arrays'])) parseArrays = args['parse-arrays']
+  if(Array.isArray(args['parse-arrays'])) parseArrays = args['parse-arrays'];
   else if(typeof args['parse-arrays']) parseArrays = [args['parse-arrays']];
 
   var geoColumns = null;
   if(args['geo-columns']) {
     var cols = args['geo-columns'].split(',');
-    if(cols.length != 2) {
-      console.error('--geo-columns argument must contain the name of two columns respectively for lattitude and longitude separeted with a comma');
+    if(cols.length !== 2) {
+      console.error('--geo-columns argument must contain the name of two columns respectively for latitude and longitude separated with a comma');
       return undefined;
     }
     geoColumns = {

--- a/bin/algolia-upload.js
+++ b/bin/algolia-upload.js
@@ -12,7 +12,7 @@ function readConfig(argv) {
   var urlStartPattern = /http(?:s)*:\/\//;
 
   if( args._.length !== 4) {
-    console.error( "Usage : algolia-upload APP_ID API_KEY indexName file|url [-d ','] [-b 10000] [--clear-index] [--parse-arrays=column] [--geo-columns=lat_col,long_col]" );
+    console.error( "Usage : algolia-upload APP_ID API_KEY indexName file|url [-d ','] [-b 10000] [--clear-index] [--parse-arrays=column] [--geo-columns=lat_col,long_col] [--arrays-delimiter=',']" );
     return undefined;
   }
 
@@ -43,6 +43,7 @@ function readConfig(argv) {
     delimiter: args['d'] || ',',
     clearIndex: args['clear-index'] || false,
     parseArrays: parseArrays || false,
+    arraysDelimiter: args['arrays-delimiter'] || ',',
     geoColumns: geoColumns
   };
 }

--- a/bin/algolia-upload.js
+++ b/bin/algolia-upload.js
@@ -12,7 +12,7 @@ function readConfig(argv) {
   var urlStartPattern = /http(?:s)*:\/\//;
 
   if( args._.length !== 4) {
-    console.error( "Usage : algolia-upload APP_ID API_KEY indexName file|url [-d ','] [-b 10000] [--clear-index] [--parse-arrays=column] [--arrays-delimiter=','] [--geo-columns=lat_col,long_col]" );
+    console.error( "Usage : algolia-upload APP_ID API_KEY indexName file|url [-d ','] [-b 10000] [--clear-index] [--parse-arrays=column] [--array-delimiter=','] [--geo-columns=lat_col,long_col]" );
     return undefined;
   }
 
@@ -43,7 +43,7 @@ function readConfig(argv) {
     delimiter: args['d'] || ',',
     clearIndex: args['clear-index'] || false,
     parseArrays: parseArrays || false,
-    arraysDelimiter: args['arrays-delimiter'] || ',',
+    arrayDelimiter: args['array-delimiter'] || ',',
     geoColumns: geoColumns
   };
 }

--- a/lib/import.js
+++ b/lib/import.js
@@ -18,7 +18,7 @@ function uploadCSVToAlgolia(inputStream, config) {
   var parser = parse({comment: '#', delimiter : config.delimiter, columns: true, auto_parse: true});
 
   var transforms = [];
-  if(config.parseArrays) transforms.push(transform(parseArrays.bind(undefined, config.parseArrays)));
+  if(config.parseArrays) transforms.push(transform(parseArrays.bind(undefined, config.parseArrays, config.arraysDelimiter)));
   if(config.geoColumns) transforms.push(transform(geoColumificater.bind(undefined, config.geoColumns)));
 
   var csvStream = transforms.reduce(function(stream, t){
@@ -47,10 +47,10 @@ function addObjectID(i, data) {
   return data;
 }
 
-function parseArrays(columnsToParse, data) {
+function parseArrays(columnsToParse, arraysDelimiter, data) {
   var res = {};
   Object.keys(data).forEach(function(k) {
-    if(columnsToParse.indexOf(k) !== -1) res[k] = data[k].split(',');
+    if(columnsToParse.indexOf(k) !== -1) res[k] = data[k].split(arraysDelimiter);
     else res[k] = data[k];
   });
   return res;

--- a/lib/import.js
+++ b/lib/import.js
@@ -9,7 +9,7 @@ var stream = require( 'stream' );
 var request = require( 'request' );
 
 var parse = require('csv-parse');
-var fs = require('fs')
+var fs = require('fs');
 var transform = require('stream-transform');
 var Batch = require( 'batch-stream' );
 
@@ -38,7 +38,7 @@ function uploadCSVFileToAlgolia(config) {
 
 function uploadCSVFromURLToAlgolia(config) {
   console.log('Reading from http : ' + config.input);
-  var httpStream = request(config.input)
+  var httpStream = request(config.input);
   uploadCSVToAlgolia(httpStream, config);
 }
 
@@ -95,7 +95,7 @@ function algoliaSaveStream(config) {
     index.clearIndex();
   }
 
-  var streamToAlgolia = new stream.Stream()
+  var streamToAlgolia = new stream.Stream();
   streamToAlgolia.writable = true;
   streamToAlgolia.write = function (data) {
     console.log('Saving to algolia');
@@ -104,9 +104,9 @@ function algoliaSaveStream(config) {
       else console.log('Saved/updated ' + content.objectIDs.length + ' records');
     } );
     return true;
-  }
+  };
   streamToAlgolia.end = function(data) {
-  }
+  };
 
   return streamToAlgolia;
 }

--- a/lib/import.js
+++ b/lib/import.js
@@ -18,7 +18,7 @@ function uploadCSVToAlgolia(inputStream, config) {
   var parser = parse({comment: '#', delimiter : config.delimiter, columns: true, auto_parse: true});
 
   var transforms = [];
-  if(config.parseArrays) transforms.push(transform(parseArrays.bind(undefined, config.parseArrays, config.arraysDelimiter)));
+  if(config.parseArrays) transforms.push(transform(parseArrays.bind(undefined, config.parseArrays, config.arrayDelimiter)));
   if(config.geoColumns) transforms.push(transform(geoColumificater.bind(undefined, config.geoColumns)));
 
   var csvStream = transforms.reduce(function(stream, t){
@@ -47,10 +47,10 @@ function addObjectID(i, data) {
   return data;
 }
 
-function parseArrays(columnsToParse, arraysDelimiter, data) {
+function parseArrays(columnsToParse, arrayDelimiter, data) {
   var res = {};
   Object.keys(data).forEach(function(k) {
-    if(columnsToParse.indexOf(k) !== -1) res[k] = data[k].split(arraysDelimiter);
+    if(columnsToParse.indexOf(k) !== -1) res[k] = data[k].split(arrayDelimiter);
     else res[k] = data[k];
   });
   return res;

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ npm install -g algolia-csv
 You must have a file in which the first row contains the name of all the fields.
 
 ```sh
-algolia-upload $APP_ID $API_KEY $indexName $file|$url [-d $delimiter] [-b $batchSizer] [--clear-index] [--parse-arrays=$column]
+algolia-upload $APP_ID $API_KEY $indexName $file|$url [-d $delimiter] [-b $batchSizer] [--clear-index] [--parse-arrays=$column] [--arrays-delimiter=$delimiter]
 ```
 
 Mandatory parameters are the aplication id, a key with write rights, the target index name and the input CSV (locally or accessible
@@ -38,8 +38,10 @@ Other parameters:
  - `-d` let you set the delimiter used in your file. This should be set in quotes. Default is ','.
  - `-b` let you set the batch size. Default is 10000.
  - `--clear-index` forces the index to be cleared before uploading the new data.
- - `--parse-arrays=column` let you specify if a column value should be splitted with ',' before uploading the data. More than one column can be set using this parameter multiple times.
- - `--geo-columns=latCol,longCol` let you specify two columns that are to  be used for creating the special algolia attribute `_geoloc`
+ - `--parse-arrays=column` let you specify if a column value should be split before uploading the data.
+   More than one column can be set using this parameter multiple times. Value will be split with `--arrays-delimiter`.
+ - `--arrays-delimiter` let you specify the delimiter used to split the values of columns defined with `--parser-arrays`. Default is ','.
+ - `--geo-columns=latCol,longCol` let you specify two columns that are to  be used for creating the special algolia attribute `_geoloc`.
 
 ### As a library
 
@@ -59,6 +61,7 @@ algoliaCsvTools.upload({
   delimiter: ',',
   clearIndex: false,
   parseArrays: ['column'],
+  arraysDelimiter: '|',
   geoColumns: {lat: 'latCol', 'lng': 'longColumn'}
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ npm install -g algolia-csv
 You must have a file in which the first row contains the name of all the fields.
 
 ```sh
-algolia-upload $APP_ID $API_KEY $indexName $file|$url [-d $delimiter] [-b $batchSizer] [--clear-index] [--parse-arrays=$column] [--arrays-delimiter=$delimiter] [--geo-columns=$latCol,$longCol]
+algolia-upload $APP_ID $API_KEY $indexName $file|$url [-d $delimiter] [-b $batchSizer] [--clear-index] [--parse-arrays=$column] [--array-delimiter=$delimiter] [--geo-columns=$latCol,$longCol]
 ```
 
 Mandatory parameters are the aplication id, a key with write rights, the target index name and the input CSV (locally or accessible
@@ -39,8 +39,8 @@ Other parameters:
  - `-b` let you set the batch size. Default is 10000.
  - `--clear-index` forces the index to be cleared before uploading the new data.
  - `--parse-arrays=column` let you specify if a column value should be split before uploading the data.
-   More than one column can be set using this parameter multiple times. Value will be split with `--arrays-delimiter`.
- - `--arrays-delimiter` let you specify the delimiter used to split the values of columns defined with `--parser-arrays`. Default is ','.
+   More than one column can be set using this parameter multiple times. Value will be split with `--array-delimiter`.
+ - `--array-delimiter` let you specify the delimiter used to split the values of columns defined with `--parse-arrays`. Default is ','.
  - `--geo-columns=latCol,longCol` let you specify two columns that are to  be used for creating the special algolia attribute `_geoloc`.
 
 ### As a library
@@ -61,7 +61,7 @@ algoliaCsvTools.upload({
   delimiter: ',',
   clearIndex: false,
   parseArrays: ['column'],
-  arraysDelimiter: '|',
+  arrayDelimiter: '|',
   geoColumns: {lat: 'latCol', 'lng': 'longColumn'}
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ npm install -g algolia-csv
 You must have a file in which the first row contains the name of all the fields.
 
 ```sh
-algolia-upload $APP_ID $API_KEY $indexName $file|$url [-d $delimiter] [-b $batchSizer] [--clear-index] [--parse-arrays=$column] [--arrays-delimiter=$delimiter]
+algolia-upload $APP_ID $API_KEY $indexName $file|$url [-d $delimiter] [-b $batchSizer] [--clear-index] [--parse-arrays=$column] [--arrays-delimiter=$delimiter] [--geo-columns=$latCol,$longCol]
 ```
 
 Mandatory parameters are the aplication id, a key with write rights, the target index name and the input CSV (locally or accessible


### PR DESCRIPTION
I had to use this great tool [while doing support](https://secure.helpscout.net/conversation/1018638967/209830/), and found it too bad to have to tell the customer that he would need to update all his CSV delimiters (it's usually `','` by default) to use the `--parse-arrays` feature, instead of simply use a specific delimiters for his arrays.

#### Changes
- Added a `--arrays-delimiter` option to specify the arrays delimiters

#### Note
Note: I kept `','` as default delimiter, but that will conflict with the default CSV delimiter, I could put another one maybe. Wdyt?